### PR TITLE
support nested objects and arrays

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.0",
-    "component/each": "0.0.1"
+    "component/each": "0.0.1",
+    "ianstormtaylor/is": "0.1.0",
+    "ndhoule/extend": "^1.0.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,8 @@
 
 var integration = require('analytics.js-integration');
 var each = require('each');
+var is = require('is');
+var extend = require('extend');
 
 /**
  * Expose `Heap` integration.
@@ -69,7 +71,7 @@ Heap.prototype.identify = function(identify) {
   var traits = identify.traits({ email: '_email' });
   var id = identify.userId();
   if (id) traits.handle = id;
-  window.heap.identify(traits);
+  window.heap.identify(clean(traits));
 };
 
 /**
@@ -82,5 +84,127 @@ Heap.prototype.identify = function(identify) {
  */
 
 Heap.prototype.track = function(track) {
-  window.heap.track(track.event(), track.properties());
+  window.heap.track(track.event(), clean(track.properties()));
 };
+
+/**
+ * Clean all nested objects and arrays.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+function clean(obj) {
+  var ret = {};
+
+  for (var k in obj) {
+    if (obj.hasOwnProperty(k)) {
+      var value = obj[k];
+      if (null == value) continue;
+
+      // date
+      if (is.date(value)) {
+        ret[k] = value.toISOString();
+        continue;
+      }
+
+      // leave boolean as is
+      if (is.boolean(value)) {
+        ret[k] = value;
+        continue;
+      }
+
+      // leave  numbers as is
+      if (is.number(value)) {
+        ret[k] = value;
+        continue;
+      }
+
+      // non objects
+      if (value.toString() !== '[object Object]') {
+        ret[k] = value.toString();
+        continue;
+      }
+
+      // json
+      // must flatten including the name of the original trait/property
+      var nestedObj = {};
+      nestedObj[k] = value;
+      var flattenedObj = flatten(nestedObj, { safe: true });
+
+      // stringify arrays inside nested object to be consistent with top level behavior of arrays
+      for (var key in flattenedObj) {
+        if (is.array(flattenedObj[key])) flattenedObj[key] = JSON.stringify(flattenedObj[key]);
+      }
+
+      ret = extend(ret, flattenedObj);
+      delete ret[k];
+    }
+  }
+
+  return ret;
+}
+
+/**
+ * Flatten nested objects
+ * taken from https://www.npmjs.com/package/flat
+ * @param {Object} obj
+ * @return {Object} obj
+ * @api public
+ */
+
+function flatten(target, opts) {
+  opts = opts || {};
+
+  var delimiter = opts.delimiter || '.';
+  var maxDepth = opts.maxDepth;
+  var currentDepth = 1;
+  var output = {};
+
+  function step(object, prev) {
+    Object.keys(object).forEach(function(key) {
+      var value = object[key];
+      var isarray = opts.safe && Array.isArray(value);
+      var type = Object.prototype.toString.call(value);
+      var isobject = type === '[object Object]' || type === '[object Array]';
+
+      var newKey = prev
+        ? prev + delimiter + key
+        : key;
+
+      if (!opts.maxDepth) {
+        maxDepth = currentDepth + 1;
+      }
+
+      if (!isarray && isobject && Object.keys(value).length && currentDepth < maxDepth) {
+        ++currentDepth;
+        return step(value, newKey);
+      }
+
+      output[newKey] = value;
+    });
+  }
+
+  step(target);
+
+  return output;
+}
+
+/**
+ * Polyfill Object.keys
+ * // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+ * Note: Had to do this because for some reason, the above will not work properly without using Object.keys
+ */
+
+if (!Object.keys) {
+  Object.keys = function(o) {
+    if (o !== Object(o)) {
+      throw new TypeError('Object.keys called on a non-object');
+    }
+    var k = [];
+    var p;
+    for (p in o) if (Object.prototype.hasOwnProperty.call(o, p)) k.push(p);
+    return k;
+  };
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,8 +87,8 @@ describe('Heap', function() {
       });
 
       it('should send traits', function() {
-        analytics.identify({ trait: true });
-        analytics.called(window.heap.identify, { trait: true });
+        analytics.identify({ trait: true, number: 1 });
+        analytics.called(window.heap.identify, { trait: true, number: 1 });
       });
 
       it('should alias email to _email', function() {
@@ -105,6 +105,38 @@ describe('Heap', function() {
         analytics.identify('id', { trait: 'trait' });
         analytics.called(window.heap.identify, { handle: 'id', id: 'id', trait: 'trait' });
       });
+
+      it('should flatten nested objects and arrays', function() {
+        analytics.identify('id', {
+          email: 'teemo@teemo.com',
+          property: 3,
+          foo: {
+            bar: {
+              hello: 'teemo'
+            },
+            cheese: ['1', 2, 'cheers'],
+            products: [
+              { A: 'Jello' },
+              { B: 'Peanut' }
+            ]
+          }
+        });
+        analytics.called(window.heap.identify, {
+          handle: 'id',
+          id: 'id',
+          _email: 'teemo@teemo.com',
+          property: 3,
+          'foo.bar.hello': 'teemo',
+          'foo.cheese': '[\"1\",2,\"cheers\"]',
+          'foo.products': '[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]'
+         });
+      });
+
+      it('should send date traits as ISOStrings', function() {
+        var date = new Date('2016');
+        analytics.identify('id', { date: date });
+        analytics.called(window.heap.identify, { handle: 'id', id: 'id', date: '2016-01-01T00:00:00.000Z' });
+      });
     });
 
     describe('#track', function() {
@@ -120,6 +152,28 @@ describe('Heap', function() {
       it('should send an event and properties', function() {
         analytics.track('event', { property: true });
         analytics.called(window.heap.track, 'event', { property: true });
+      });
+
+      it('should flatten nested objects and arrays', function() {
+        analytics.track('event', {
+          property: 3,
+          foo: {
+            bar: {
+              hello: 'teemo'
+            },
+            cheese: ['1', 2, 'cheers'],
+            products: [
+              { A: 'Jello' },
+              { B: 'Peanut' }
+            ]
+          }
+        });
+        analytics.called(window.heap.track, 'event', {
+          property: 3,
+          'foo.bar.hello': 'teemo',
+          'foo.cheese': '[\"1\",2,\"cheers\"]',
+          'foo.products': '[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]'
+         });
       });
     });
   });


### PR DESCRIPTION
this is to have parity with how we flatten objects and arrays on the server side.

this is in tandem with this [PR](https://github.com/segmentio/integration-heap/pull/6)

@f2prateek @sperand-io @radiofreejohn

I basically took the same node module i used (`flat`) and used it here (gave credit to source code of course) and added a polyfill for `Object.keys` because for some crazy reason I could not replicate the exact behavior by using `for (var prop in obj)....` method.
