### PR TITLE
fix flattening

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,26 +129,34 @@ function clean(obj) {
         continue;
       }
 
+      // arrays of objects (eg. `products` array)
+      if (toString.call(value) === '[object Array]') {
+        ret = extend(ret, trample(k, value));
+        continue;
+      }
+
       // non objects
       if (toString.call(value) !== '[object Object]') {
         ret[k] = value.toString();
         continue;
       }
 
-      // json
-      // must flatten including the name of the original trait/property
-      var nestedObj = {};
-      nestedObj[k] = value;
-      var flattenedObj = flatten(nestedObj, { safe: true });
-
-      // stringify arrays inside nested object to be consistent with top level behavior of arrays
-      for (var key in flattenedObj) {
-        if (is.array(flattenedObj[key])) flattenedObj[key] = JSON.stringify(flattenedObj[key]);
-      }
-
-      ret = extend(ret, flattenedObj);
-      delete ret[k];
+      ret = extend(ret, trample(k, value));
     }
+  }
+  // json
+  // must flatten including the name of the original trait/property
+  function trample(key, value) {
+    var nestedObj = {};
+    nestedObj[key] = value;
+    var flattenedObj = flatten(nestedObj, { safe: true });
+
+    // stringify arrays inside nested object to be consistent with top level behavior of arrays
+    for (var k in flattenedObj) {
+      if (is.array(flattenedObj[k])) flattenedObj[k] = JSON.stringify(flattenedObj[k]);
+    }
+
+    return flattenedObj;
   }
 
   return ret;

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-heap#readme",
   "dependencies": {
     "@ndhoule/extend": "^2.0.0",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.0.0",
     "@segment/to-iso-string": "^1.0.1",
     "component-each": "^0.2.6",
     "is": "^3.1.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,12 +117,12 @@ describe('Heap', function() {
             bar: {
               hello: 'teemo'
             },
-            cheese: ['1', 2, 'cheers'],
-            products: [
-              { A: 'Jello' },
-              { B: 'Peanut' }
-            ]
-          }
+            cheese: ['1', 2, 'cheers']
+          },
+          products: [
+          { A: 'Jello', B: 1 },
+          { B: 'Peanut', C: true }
+          ]
         });
         analytics.called(window.heap.identify, 'id');
         analytics.called(window.heap.addUserProperties, {
@@ -131,7 +131,7 @@ describe('Heap', function() {
           property: 3,
           'foo.bar.hello': 'teemo',
           'foo.cheese': '[\"1\",2,\"cheers\"]',
-          'foo.products': '[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]'
+          products: '[{\"A\":\"Jello\",\"B\":1},{\"B\":\"Peanut\",\"C\":true}]'
         });
       });
 
@@ -165,23 +165,27 @@ describe('Heap', function() {
 
       it('should flatten nested objects and arrays', function() {
         analytics.track('event', {
+          hello: 'hello',
           property: 3,
           foo: {
             bar: {
               hello: 'teemo'
             },
-            cheese: ['1', 2, 'cheers'],
-            products: [
-              { A: 'Jello' },
-              { B: 'Peanut' }
-            ]
-          }
+            cheese: ['1', 2, 'cheers']
+          },
+          products: [
+          { A: 'Jello', B: 'haha' },
+          { A: 'Peanut', B: true }
+          ],
+          topArray: ['1', 2, true]
         });
         analytics.called(window.heap.track, 'event', {
+          hello: 'hello',
           property: 3,
           'foo.bar.hello': 'teemo',
           'foo.cheese': '[\"1\",2,\"cheers\"]',
-          'foo.products': '[{\"A\":\"Jello\"},{\"B\":\"Peanut\"}]'
+          products: '[{\"A\":\"Jello\",\"B\":\"haha\"},{\"A\":\"Peanut\",\"B\":true}]',
+          topArray: '[\"1\",2,true]'
         });
       });
     });


### PR DESCRIPTION
This issue was brought up in our partner slack channel:
# Issue:

we were properly flattening any compound objects like nested arrays, objects **ONLY** if it was nested under an object.

However, top level arrays that contained objects were being sent as `[object Object]` such as the `products` array from `Completed Order` events.

I had to catch the array of objects before the `toString.call(value) !== '[object Object]'` if test because otherwise, `products` array would fall in that block, while objects of objects/arrays were not and thus properly flattened.

This PR should properly stringify the entire nested array and also continue to take care of any objects that include compound objects.
- [ ] server side PR

@f2prateek 
