### PR TITLE
Update heap integration for heap.js v4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,9 +23,10 @@ var Heap = module.exports = integration('Heap')
   .tag('<script src="//cdn.heapanalytics.com/js/heap-{{ appId }}.js">');
 
 /**
- * Identity field passed to Heap for standard identify requests.
+ * Identity fields passed to Heap for identify requests.
  */
 var SEGMENT_IDENTITY_FIELD = 'Segment User Id';
+var CROSS_DOMAIN_IDENTITY_FIELD = 'Segment Cross-domain Id';
 
 /**
  * Initialize.
@@ -80,7 +81,9 @@ Heap.prototype.loaded = function() {
 Heap.prototype.identify = function(identify) {
   var traits = identify.traits({ email: '_email' });
   var id = identify.userId();
+  var crossDomainId = traits.crossDomainId;
   if (id) window.heap.identify(id, SEGMENT_IDENTITY_FIELD);
+  if (crossDomainId) window.heap.identify(crossDomainId, CROSS_DOMAIN_IDENTITY_FIELD);
   window.heap.addUserProperties(clean(traits));
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ Heap.prototype.initialize = function() {
       };
     };
 
-    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
+    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
     each(heapMethods, function(method) {
       window.heap[method] = methodFactory(method);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,11 @@ var Heap = module.exports = integration('Heap')
   .tag('<script src="//cdn.heapanalytics.com/js/heap-{{ appId }}.js">');
 
 /**
+ * Identity field passed to Heap for standard identify requests.
+ */
+var SEGMENT_IDENTITY_FIELD = 'Segment User Id';
+
+/**
  * Initialize.
  *
  * https://heapanalytics.com/docs/installation#web
@@ -75,7 +80,7 @@ Heap.prototype.loaded = function() {
 Heap.prototype.identify = function(identify) {
   var traits = identify.traits({ email: '_email' });
   var id = identify.userId();
-  if (id) window.heap.identify(id);
+  if (id) window.heap.identify(id, SEGMENT_IDENTITY_FIELD);
   window.heap.addUserProperties(clean(traits));
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,6 +141,12 @@ describe('Heap', function() {
         analytics.called(window.heap.identify, 'id', 'Segment User Id');
         analytics.called(window.heap.addUserProperties, { id: 'id', date: '2016-01-01T00:00:00.000Z' });
       });
+
+      it('should call identify with crossDomainId if included', function() {
+        analytics.identify({ crossDomainId: 'crossDomainId' });
+        analytics.called(window.heap.identify, 'crossDomainId', 'Segment Cross-domain Id');
+        analytics.called(window.heap.addUserProperties, { crossDomainId: 'crossDomainId' });
+      });
     });
 
     describe('#track', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,14 +98,14 @@ describe('Heap', function() {
         analytics.called(window.heap.addUserProperties, { trait: true, _email: 'email@email.org' });
       });
 
-      it('should send id as handle', function() {
+      it('should send id as handle with the correct field name', function() {
         analytics.identify('id');
-        analytics.called(window.heap.identify, 'id');
+        analytics.called(window.heap.identify, 'id', 'Segment User Id');
       });
 
       it('should send id as handle and traits', function() {
         analytics.identify('id', { trait: 'trait' });
-        analytics.called(window.heap.identify, 'id');
+        analytics.called(window.heap.identify, 'id', 'Segment User Id');
         analytics.called(window.heap.addUserProperties, { id: 'id', trait: 'trait' });
       });
 
@@ -124,7 +124,7 @@ describe('Heap', function() {
           { B: 'Peanut', C: true }
           ]
         });
-        analytics.called(window.heap.identify, 'id');
+        analytics.called(window.heap.identify, 'id', 'Segment User Id');
         analytics.called(window.heap.addUserProperties, {
           id: 'id',
           _email: 'teemo@teemo.com',
@@ -138,7 +138,7 @@ describe('Heap', function() {
       it('should send date traits as ISOStrings', function() {
         var date = new Date('2016');
         analytics.identify('id', { date: date });
-        analytics.called(window.heap.identify, 'id');
+        analytics.called(window.heap.identify, 'id', 'Segment User Id');
         analytics.called(window.heap.addUserProperties, { id: 'id', date: '2016-01-01T00:00:00.000Z' });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ describe('Heap', function() {
       });
 
       it('should stub window.heap with the right methods', function() {
-        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
+        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
         analytics.assert(!window.heap);
         analytics.initialize();
         each(methods, function(method) {


### PR DESCRIPTION
The newest version of the Heap tracker includes the following changes:
- The introduction of `heap.resetIdentity`
- The ability to pass in an identity field as the second argument to `heap.identify`

This pull request does the following:
- Stubs out `resetIdentity` on the heap object
- Passes in a default identity field on normal identify calls
- When identify calls include `crossDomainId` as a trait, calls identify with a special identity field