### PR TITLE
Stop sending identity fields to heap.identify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,12 +23,6 @@ var Heap = module.exports = integration('Heap')
   .tag('<script src="//cdn.heapanalytics.com/js/heap-{{ appId }}.js">');
 
 /**
- * Identity fields passed to Heap for identify requests.
- */
-var SEGMENT_IDENTITY_FIELD = 'Segment User Id';
-var CROSS_DOMAIN_IDENTITY_FIELD = 'Segment Cross-domain Id';
-
-/**
  * Initialize.
  *
  * https://heapanalytics.com/docs/installation#web
@@ -48,7 +42,7 @@ Heap.prototype.initialize = function() {
       };
     };
 
-    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
+    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
     each(heapMethods, function(method) {
       window.heap[method] = methodFactory(method);
     });
@@ -81,9 +75,7 @@ Heap.prototype.loaded = function() {
 Heap.prototype.identify = function(identify) {
   var traits = identify.traits({ email: '_email' });
   var id = identify.userId();
-  var crossDomainId = traits.crossDomainId;
-  if (id) window.heap.identify(id, SEGMENT_IDENTITY_FIELD);
-  if (crossDomainId) window.heap.identify(crossDomainId, CROSS_DOMAIN_IDENTITY_FIELD);
+  if (id) window.heap.identify(id);
   window.heap.addUserProperties(clean(traits));
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ Heap.prototype.initialize = function() {
       };
     };
 
-    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
+    var heapMethods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
     each(heapMethods, function(method) {
       window.heap[method] = methodFactory(method);
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ describe('Heap', function() {
       });
 
       it('should stub window.heap with the right methods', function() {
-        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
+        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
         analytics.assert(!window.heap);
         analytics.initialize();
         each(methods, function(method) {
@@ -98,14 +98,14 @@ describe('Heap', function() {
         analytics.called(window.heap.addUserProperties, { trait: true, _email: 'email@email.org' });
       });
 
-      it('should send id as handle with the correct field name', function() {
+      it('should send id as handle', function() {
         analytics.identify('id');
-        analytics.called(window.heap.identify, 'id', 'Segment User Id');
+        analytics.called(window.heap.identify, 'id');
       });
 
       it('should send id as handle and traits', function() {
         analytics.identify('id', { trait: 'trait' });
-        analytics.called(window.heap.identify, 'id', 'Segment User Id');
+        analytics.called(window.heap.identify, 'id');
         analytics.called(window.heap.addUserProperties, { id: 'id', trait: 'trait' });
       });
 
@@ -124,7 +124,7 @@ describe('Heap', function() {
           { B: 'Peanut', C: true }
           ]
         });
-        analytics.called(window.heap.identify, 'id', 'Segment User Id');
+        analytics.called(window.heap.identify, 'id');
         analytics.called(window.heap.addUserProperties, {
           id: 'id',
           _email: 'teemo@teemo.com',
@@ -138,14 +138,8 @@ describe('Heap', function() {
       it('should send date traits as ISOStrings', function() {
         var date = new Date('2016');
         analytics.identify('id', { date: date });
-        analytics.called(window.heap.identify, 'id', 'Segment User Id');
+        analytics.called(window.heap.identify, 'id');
         analytics.called(window.heap.addUserProperties, { id: 'id', date: '2016-01-01T00:00:00.000Z' });
-      });
-
-      it('should call identify with crossDomainId if included', function() {
-        analytics.identify({ crossDomainId: 'crossDomainId' });
-        analytics.called(window.heap.identify, 'crossDomainId', 'Segment Cross-domain Id');
-        analytics.called(window.heap.addUserProperties, { crossDomainId: 'crossDomainId' });
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ describe('Heap', function() {
       });
 
       it('should stub window.heap with the right methods', function() {
-        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty'];
+        var methods = ['addEventProperties', 'addUserProperties', 'clearEventProperties', 'identify', 'removeEventProperty', 'setEventProperties', 'track', 'unsetEventProperty', 'resetIdentity'];
         analytics.assert(!window.heap);
         analytics.initialize();
         each(methods, function(method) {


### PR DESCRIPTION
Sending an identify field along with each identify call is causing some problems for a small subset of our customers, and we'd like to revert it until we figure out a better long-term solution. Sorry for the churn. This pull request is structured as a full revert of my previous PR, followed by the re-addition of stubbing out `heap.resetIdentity`, as this is still necessary.